### PR TITLE
Added autologin

### DIFF
--- a/src/components/auth/Auth.tsx
+++ b/src/components/auth/Auth.tsx
@@ -11,7 +11,6 @@ const oidcConfig = {
     "DILUV_WEBSITE",
   responseType: "id_token",
   scope: "openid profile",
-  autoSignIn: false,
   redirectUri: "http://localhost:3000"
 };
 


### PR DESCRIPTION
Auto login should always happen as unless they are logged out from the provider they should keep being signed in. (Kind of blocked by a PR to oidc-react)